### PR TITLE
feat(webp_to_jpeg): add hook mode for auto-conversion on scene update

### DIFF
--- a/plugins/webp_to_jpeg/README.md
+++ b/plugins/webp_to_jpeg/README.md
@@ -26,9 +26,28 @@ Manual install: clone the `plugins/webp_to_jpeg/` directory into Stash's `plugin
 
 ## Usage
 
+### Manual bulk conversion
+
 1. (Optional) Enable **Dry Run** in plugin settings to see how many covers are WEBP without making any changes.
 2. **Settings → Tasks**, click **Convert WEBP Covers to JPEG**.
 3. Final summary (scanned / found / converted / errors) logged at INFO level.
+
+### Hook mode (automatic per-scene conversion)
+
+The plugin also registers two Stash hooks that fire automatically — no manual task run needed:
+
+| Hook | When it fires |
+|---|---|
+| `Scene.Update.Post` | After any operation that updates a scene with a new cover (e.g. scraping, identify). Fires only if `cover_image` is in the changed fields; other scene edits are ignored. |
+| `Scene.Create.Post` | After a new scene is created with a cover set at creation time. Fires only if `input.cover_image` is non-empty. |
+
+When either hook fires, the plugin fetches the scene's cover via `/scene/{id}/screenshot`, checks for WEBP magic bytes, and converts to JPEG in-place — exactly as the bulk task does, but for that one scene.
+
+**Accepted caveat:** Stash's own auto-generated screenshots (video frame captures, triggered by "Generate → Cover images") do **not** fire `Scene.Update.Post`. Those covers are already JPEG, so this is not a problem in practice.
+
+**To disable hook mode** without uninstalling: go to **Settings → Plugins**, find "WEBP to JPEG Cover Converter", and toggle off the hooks. The manual task continues to work regardless.
+
+**Dry Run** applies to hook mode too — if enabled, the plugin logs what it would convert but makes no changes.
 
 ## Settings
 
@@ -52,3 +71,4 @@ Manual install: clone the `plugins/webp_to_jpeg/` directory into Stash's `plugin
 - Scenes with no cover are skipped silently.
 - JPEG / PNG / any non-WEBP cover is left untouched.
 - URL structure of `paths.screenshot` is unchanged — clients keep working.
+- Hook mode does not catch Stash's auto-generated frame-grab covers (those bypass `Scene.Update.Post`). Use the bulk task to clean up existing WEBP covers before relying on hooks for new ones.

--- a/plugins/webp_to_jpeg/webp_to_jpeg.py
+++ b/plugins/webp_to_jpeg/webp_to_jpeg.py
@@ -350,6 +350,80 @@ def run_conversion(
     return summary
 
 
+def run_hook(
+    stash: StashInterface, conn: dict[str, Any], settings: dict[str, Any], args: dict[str, Any]
+) -> None:
+    """Handle a Scene.Update.Post or Scene.Create.Post hook invocation.
+
+    Fetches the single scene's cover, checks if it's WEBP, and converts it.
+    The thread pool and progress reporting used by the bulk task are not needed
+    here — we always process exactly one scene.
+    """
+    hook_ctx = args.get("hookContext") or {}
+    trigger = hook_ctx.get("type", "")
+    input_fields: list[str] = hook_ctx.get("inputFields") or []
+    hook_input: dict[str, Any] = hook_ctx.get("input") or {}
+
+    # Filter: for Update we only care when the cover was actually changed.
+    # For Create, inputFields population is uncertain; fall back to checking
+    # whether input.cover_image is truthy.
+    if trigger == "Scene.Update.Post":
+        if "cover_image" not in input_fields:
+            log.debug("Hook skipped: cover_image not in inputFields")
+            print(json.dumps({"output": "skipped: cover_image not in inputFields"}))
+            return
+    elif trigger == "Scene.Create.Post":
+        if not hook_input.get("cover_image"):
+            log.debug("Hook skipped: cover_image not present in input")
+            print(json.dumps({"output": "skipped: cover_image not present in input"}))
+            return
+    else:
+        log.debug(f"Hook skipped: unexpected trigger type '{trigger}'")
+        print(json.dumps({"output": f"skipped: unexpected trigger '{trigger}'"}))
+        return
+
+    scene_id = hook_ctx.get("id")
+    if not scene_id:
+        log.error("Hook: hookContext.id missing")
+        print(json.dumps({"output": None, "error": "hookContext.id missing"}))
+        sys.exit(1)
+
+    sid = str(scene_id)
+    dry_run = settings["dryRun"]
+    quality = settings["jpegQuality"]
+
+    if dry_run:
+        log.info(f"Hook dry run — would process scene {sid}")
+
+    log.info(f"Hook triggered ({trigger}) for scene {sid}")
+    headers = auth_headers(conn)
+    result = _process_scene(sid, conn, headers, stash, quality, dry_run)
+
+    status = result["status"]
+    if status == "converted":
+        msg = f"Scene {sid}: converted WEBP cover to JPEG"
+        log.info(msg)
+        print(json.dumps({"output": msg}))
+    elif status == "would_convert":
+        msg = f"Scene {sid}: dry run — would convert WEBP cover to JPEG"
+        log.info(msg)
+        print(json.dumps({"output": msg}))
+    elif status == "not_webp":
+        msg = f"Scene {sid}: cover is not WEBP, nothing to do"
+        log.debug(msg)
+        print(json.dumps({"output": msg}))
+    elif status == "fetch_failed":
+        err = f"Scene {sid}: could not fetch cover image"
+        log.warning(err)
+        print(json.dumps({"error": err}))
+        sys.exit(1)
+    else:
+        err = f"Scene {sid}: {status}"
+        log.error(err)
+        print(json.dumps({"output": None, "error": err}))
+        sys.exit(1)
+
+
 def main() -> None:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -377,6 +451,15 @@ def main() -> None:
             print(json.dumps({"output": summary}))
         except Exception as e:
             log.error(f"Task failed: {e}")
+            print(json.dumps({"output": None, "error": str(e)}))
+            sys.exit(1)
+    elif mode == "hook":
+        try:
+            run_hook(stash, conn, settings, args)
+        except SystemExit:
+            raise
+        except Exception as e:
+            log.error(f"Hook failed: {e}")
             print(json.dumps({"output": None, "error": str(e)}))
             sys.exit(1)
     else:

--- a/plugins/webp_to_jpeg/webp_to_jpeg.yml
+++ b/plugins/webp_to_jpeg/webp_to_jpeg.yml
@@ -1,6 +1,6 @@
 name: WEBP to JPEG Cover Converter
 description: Finds scene covers stored as WEBP and re-encodes them as JPEG in-place, preserving the original scraped artwork. Useful for clients like HereSphere that do not render WEBP.
-version: 0.3.0
+version: 0.4.0
 url: https://github.com/pastelfinches/stash-plugins
 # requires: PythonDepManager
 
@@ -17,6 +17,20 @@ tasks:
     description: Scan all scenes, detect WEBP covers, and convert them to JPEG. Enable "Dry Run" in plugin settings to preview without making changes.
     defaultArgs:
       mode: convert
+
+hooks:
+  - name: Auto-convert on Scene Update
+    description: Automatically convert newly-set WEBP covers to JPEG when a scene is updated with a new cover image (e.g., after scraping).
+    triggeredBy:
+      - Scene.Update.Post
+    defaultArgs:
+      mode: hook
+  - name: Auto-convert on Scene Create
+    description: Automatically convert WEBP covers to JPEG when a new scene is created with a cover image.
+    triggeredBy:
+      - Scene.Create.Post
+    defaultArgs:
+      mode: hook
 
 settings:
   dryRun:

--- a/tests/test_webp_to_jpeg_hook.py
+++ b/tests/test_webp_to_jpeg_hook.py
@@ -1,0 +1,309 @@
+"""Unit tests for the hook dispatch logic in the WEBP→JPEG plugin.
+
+Tests cover:
+- Scene.Update.Post: skip when cover_image not in inputFields
+- Scene.Update.Post: process when cover_image is in inputFields
+- Scene.Create.Post: skip when input.cover_image is falsy
+- Scene.Create.Post: process when input.cover_image is truthy
+- Unknown trigger type: gracefully skip
+- hookContext.id missing: exit non-zero
+- dry_run respected in hook mode
+- convert_failed / update_failed propagate as errors
+
+All tests mock at the boundary — no network, no Stash instance.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import webp_to_jpeg as w2j
+from PIL import Image
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_webp_bytes(size: tuple[int, int] = (16, 16)) -> bytes:
+    img = Image.new("RGB", size, (200, 100, 50))
+    buf = io.BytesIO()
+    img.save(buf, format="WEBP", quality=80)
+    return buf.getvalue()
+
+
+def make_jpeg_bytes(size: tuple[int, int] = (16, 16)) -> bytes:
+    img = Image.new("RGB", size, (200, 100, 50))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=80)
+    return buf.getvalue()
+
+
+def _default_settings() -> dict[str, Any]:
+    return {"dryRun": False, "jpegQuality": 92, "workers": 8}
+
+
+def _make_stub_stash() -> MagicMock:
+    stash = MagicMock()
+    stash.update_scene.return_value = None
+    return stash
+
+
+def _run_hook_capturing_stdout(
+    stash: MagicMock,
+    conn: dict[str, Any],
+    settings: dict[str, Any],
+    args: dict[str, Any],
+) -> tuple[dict[str, Any], int]:
+    """Run run_hook(), capture stdout JSON, and return (payload, exit_code)."""
+    captured: list[str] = []
+
+    def fake_print(s: str, **_kwargs: Any) -> None:
+        captured.append(s)
+
+    exit_code = 0
+    with patch("builtins.print", side_effect=fake_print):
+        try:
+            w2j.run_hook(stash, conn, settings, args)
+        except SystemExit as exc:
+            exit_code = int(exc.code) if exc.code is not None else 1
+
+    payload: dict[str, Any] = {}
+    if captured:
+        payload = json.loads(captured[-1])
+    return payload, exit_code
+
+
+# ---------------------------------------------------------------------------
+# Scene.Update.Post — filtering on inputFields
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePostFiltering:
+    """cover_image must appear in inputFields to trigger work."""
+
+    def _args(self, input_fields: list[str], scene_id: int = 42) -> dict[str, Any]:
+        return {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Update.Post",
+                "id": scene_id,
+                "input": {"id": str(scene_id)},
+                "inputFields": input_fields,
+            },
+        }
+
+    def test_skips_when_cover_image_absent_from_input_fields(self):
+        stash = _make_stub_stash()
+        args = self._args(["title", "tag_ids"])
+        payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "skipped" in payload.get("output", "")
+        stash.update_scene.assert_not_called()
+
+    def test_processes_when_cover_image_in_input_fields(self):
+        stash = _make_stub_stash()
+        args = self._args(["cover_image", "title"])
+        webp = make_webp_bytes()
+
+        with patch.object(w2j, "fetch_cover", return_value=webp):
+            payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "converted" in payload.get("output", "")
+        stash.update_scene.assert_called_once()
+
+    def test_skips_empty_input_fields_list(self):
+        stash = _make_stub_stash()
+        args = self._args([])
+        payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "skipped" in payload.get("output", "")
+        stash.update_scene.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Scene.Create.Post — filtering on input.cover_image
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePostFiltering:
+    """For Create hooks, fall back to checking input.cover_image is truthy."""
+
+    def _args(self, cover_image: Any, scene_id: int = 7) -> dict[str, Any]:
+        return {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Create.Post",
+                "id": scene_id,
+                "input": {"id": str(scene_id), "cover_image": cover_image},
+                "inputFields": [],  # may be empty for Create
+            },
+        }
+
+    @pytest.mark.parametrize("cover_value", [None, "", 0, False])
+    def test_skips_when_cover_image_falsy(self, cover_value: Any):
+        stash = _make_stub_stash()
+        args = self._args(cover_value)
+        payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "skipped" in payload.get("output", "")
+        stash.update_scene.assert_not_called()
+
+    def test_processes_when_cover_image_truthy(self):
+        stash = _make_stub_stash()
+        # The actual value doesn't matter — we fetch via HTTP anyway.
+        args = self._args("https://example.com/cover.webp")
+        webp = make_webp_bytes()
+
+        with patch.object(w2j, "fetch_cover", return_value=webp):
+            payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "converted" in payload.get("output", "")
+        stash.update_scene.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Non-WEBP cover — no-op
+# ---------------------------------------------------------------------------
+
+
+class TestNonWebpCover:
+    def test_not_webp_yields_no_op_output(self):
+        stash = _make_stub_stash()
+        args = {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Update.Post",
+                "id": 10,
+                "input": {"id": "10"},
+                "inputFields": ["cover_image"],
+            },
+        }
+        jpeg = make_jpeg_bytes()
+
+        with patch.object(w2j, "fetch_cover", return_value=jpeg):
+            payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "not WEBP" in payload.get("output", "") or "nothing to do" in payload.get(
+            "output", ""
+        )
+        stash.update_scene.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_logs_would_convert_without_uploading(self):
+        stash = _make_stub_stash()
+        settings = {**_default_settings(), "dryRun": True}
+        args = {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Update.Post",
+                "id": 99,
+                "input": {"id": "99"},
+                "inputFields": ["cover_image"],
+            },
+        }
+        webp = make_webp_bytes()
+
+        with patch.object(w2j, "fetch_cover", return_value=webp):
+            payload, code = _run_hook_capturing_stdout(stash, {}, settings, args)
+
+        assert code == 0
+        assert "dry run" in payload.get("output", "").lower() or "would convert" in payload.get(
+            "output", ""
+        ).lower()
+        stash.update_scene.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestHookErrorCases:
+    def test_unknown_trigger_type_skips_gracefully(self):
+        stash = _make_stub_stash()
+        args = {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Studio.Update.Post",
+                "id": 1,
+                "input": {},
+                "inputFields": [],
+            },
+        }
+        payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code == 0
+        assert "skipped" in payload.get("output", "")
+        stash.update_scene.assert_not_called()
+
+    def test_missing_scene_id_exits_nonzero(self):
+        stash = _make_stub_stash()
+        args = {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Update.Post",
+                # 'id' intentionally omitted
+                "input": {},
+                "inputFields": ["cover_image"],
+            },
+        }
+        payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code != 0
+        assert payload.get("error")
+
+    def test_fetch_failed_exits_nonzero(self):
+        stash = _make_stub_stash()
+        args = {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Update.Post",
+                "id": 5,
+                "input": {"id": "5"},
+                "inputFields": ["cover_image"],
+            },
+        }
+
+        # fetch_cover returns None → fetch_failed status
+        with patch.object(w2j, "fetch_cover", return_value=None):
+            payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code != 0
+        assert payload.get("error")
+
+    def test_update_failed_exits_nonzero(self):
+        stash = _make_stub_stash()
+        stash.update_scene.side_effect = RuntimeError("DB error")
+        args = {
+            "mode": "hook",
+            "hookContext": {
+                "type": "Scene.Update.Post",
+                "id": 6,
+                "input": {"id": "6"},
+                "inputFields": ["cover_image"],
+            },
+        }
+        webp = make_webp_bytes()
+
+        with patch.object(w2j, "fetch_cover", return_value=webp):
+            payload, code = _run_hook_capturing_stdout(stash, {}, _default_settings(), args)
+
+        assert code != 0
+        assert payload.get("error")


### PR DESCRIPTION
## Summary

- Registers `Scene.Update.Post` and `Scene.Create.Post` hooks so WEBP covers are converted immediately after a scrape or identify saves a new cover image — no manual task run required.
- The existing **Convert WEBP Covers to JPEG** bulk task is unchanged and fully functional.
- Version bumped `0.3.0 → 0.4.0` (minor — additive, non-breaking).

## Behaviour

| Trigger | Filter | Action |
|---|---|---|
| `Scene.Update.Post` | `cover_image` must be in `inputFields`; other edits (tag changes, ratings, etc.) are skipped | Fetch cover via `/scene/{id}/screenshot`, detect WEBP, convert and upload |
| `Scene.Create.Post` | `input.cover_image` must be truthy (inputFields may be empty for Create events) | Same pipeline |

Re-entrancy: `StashInterface` sends the session cookie automatically, so the `sceneUpdate` write-back does not retrigger the hook.

**Accepted caveat:** Stash's own auto-generated frame-grab covers (from "Generate → Cover images") do not fire `Scene.Update.Post`. Those covers are JPEG, so this is a non-issue in practice.

`dryRun` setting is honoured in hook mode. `workers` is not used (single-scene path).

## Testing done

- 14 new unit tests in `tests/test_webp_to_jpeg_hook.py`:
  - `Scene.Update.Post`: skip when `cover_image` absent/empty in `inputFields`; process when present
  - `Scene.Create.Post`: skip on `None`/`""`/`0`/`False`; process on truthy value
  - Non-WEBP cover: no-op, exit 0
  - Dry run: no upload, correct output message
  - Unknown trigger type: graceful skip, exit 0
  - Missing `hookContext.id`: exit non-zero with `error` key
  - `fetch_failed`: exit non-zero
  - `update_failed` (Stash raises): exit non-zero
- All 32 unit tests pass (14 new + 18 pre-existing).
- `ruff check` — 0 violations.
- `pyright` — 0 new violations (pre-existing unresolvable import stubs for PIL/stashapi/pytest are unchanged).

## Checklist

- [ ] Reviewer: confirm hook YAML syntax matches Stash manifest schema (triggeredBy / defaultArgs)
- [ ] Reviewer: smoke-test hook firing after scraping a scene with a WEBP cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)