### PR TITLE
fix(vr_preview_flatten): raise default mp4 encode quality

### DIFF
--- a/plugins/vr_preview_flatten/README.md
+++ b/plugins/vr_preview_flatten/README.md
@@ -91,7 +91,8 @@ Without any modifier tags, a VR/AR-only scene is assumed to be **SBS + equirecta
 | `defaultProjection` | string | `equirect` | `equirect` / `fisheye` / `flat`. `flat` skips reprojection (crops one eye only). |
 | `outputHFov` / `outputVFov` | number | `90` / `90` | Horizontal/vertical FOV of the flattened output in degrees. |
 | `ffmpegBin` / `ffprobeBin` | string | `ffmpeg` / `ffprobe` | Override if not on PATH. |
-| `crf` | number | `23` | x264 CRF for the re-encoded mp4 preview. Lower = bigger + sharper. |
+| `crf` | number | `18` | x264 CRF for the re-encoded mp4 preview. Lower = bigger + sharper. 18 is near-visually-lossless on the second encode pass; bump to 15 if you still see quality loss. |
+| `preset` | string | `slower` | x264 preset. Previews are short and small, so encode speed barely matters — `slower` gives better compression at the same CRF. Drop to `medium` / `fast` if you want quicker runs. |
 
 ## Idempotency
 

--- a/plugins/vr_preview_flatten/vr_preview_flatten.py
+++ b/plugins/vr_preview_flatten/vr_preview_flatten.py
@@ -124,7 +124,8 @@ DEFAULTS: dict[str, Any] = {
     "outputVFov": 90,
     "ffmpegBin": "ffmpeg",
     "ffprobeBin": "ffprobe",
-    "crf": 23,
+    "crf": 18,
+    "preset": "slower",
 }
 
 
@@ -176,6 +177,7 @@ def load_settings(stash: StashInterface) -> dict[str, Any]:
         "ffmpegBin",
         "ffprobeBin",
         "defaultProjection",
+        "preset",
     ):
         v = str(merged.get(key) or "").strip()
         merged[key] = v or str(DEFAULTS[key])
@@ -310,20 +312,28 @@ def find_preview_files(
 ) -> tuple[Path | None, Path | None]:
     """Locate the on-disk animated preview (mp4) and webp preview for a scene.
 
+    Stash stores these as `<generated>/screenshots/<checksum>.{mp4,webp}`.
+    Older or patched layouts may place them directly under `<generated>/`, so
+    we try both and return the first hit for each format.
+
     Returns (mp4_path_or_none, webp_path_or_none).
     """
     gp = Path(generated_path)
+    search_dirs = [gp / "screenshots", gp]
     mp4_path: Path | None = None
     webp_path: Path | None = None
     for c in scene_checksums(scene):
-        if mp4_path is None:
-            cand = gp / f"{c}.mp4"
-            if cand.exists():
-                mp4_path = cand
-        if webp_path is None:
-            cand = gp / f"{c}.webp"
-            if cand.exists():
-                webp_path = cand
+        for base in search_dirs:
+            if mp4_path is None:
+                cand = base / f"{c}.mp4"
+                if cand.exists():
+                    mp4_path = cand
+            if webp_path is None:
+                cand = base / f"{c}.webp"
+                if cand.exists():
+                    webp_path = cand
+            if mp4_path and webp_path:
+                break
         if mp4_path and webp_path:
             break
     return mp4_path, webp_path
@@ -426,7 +436,14 @@ def _run_ffmpeg(cmd: list[str]) -> tuple[int, str]:
 def flatten_mp4(
     src: Path, vf: str, settings: dict[str, Any]
 ) -> tuple[bool, str]:
-    """Re-encode the animated mp4 preview with the filter graph applied."""
+    """Re-encode the animated mp4 preview with the filter graph applied.
+
+    Previews are short (~10s) and small (~300KB). Quality matters more than
+    encode speed here — the file is already a lossy artifact of Stash's own
+    preview generation, so we're on the second encode pass and the margin
+    for further degradation is thin. Default to CRF 18 + slower preset; the
+    per-scene time cost is tens of milliseconds.
+    """
     tmp = src.with_suffix(src.suffix + ".tmp.mp4")
     cmd = [
         settings["ffmpegBin"],
@@ -443,9 +460,13 @@ def flatten_mp4(
         "-c:v",
         "libx264",
         "-preset",
-        "veryfast",
+        settings["preset"],
         "-crf",
         str(settings["crf"]),
+        "-profile:v",
+        "high",
+        "-pix_fmt",
+        "yuv420p",
         "-movflags",
         "+faststart",
         str(tmp),

--- a/plugins/vr_preview_flatten/vr_preview_flatten.yml
+++ b/plugins/vr_preview_flatten/vr_preview_flatten.yml
@@ -1,6 +1,6 @@
 name: VR Preview Flattener
 description: Re-render scene preview videos for VR/AR scenes — crop one eye and (optionally) unwrap fisheye/equirectangular projection so hover-previews are watchable in a normal browser. Manual task only; StashDB tags drive per-scene strategy.
-version: 0.1.0
+version: 0.2.0
 url: https://github.com/pastelfinches/stash-plugins
 # requires: PythonDepManager
 
@@ -93,5 +93,9 @@ settings:
     type: STRING
   crf:
     displayName: Output CRF (leave 0 for default)
-    description: x264 CRF quality for the re-encoded preview. Default 23. Lower = larger & higher quality.
+    description: x264 CRF quality for the re-encoded preview. Default 18 (near-visually-lossless on second encode pass). Lower = larger & higher quality. Range 1-51.
     type: NUMBER
+  preset:
+    displayName: x264 preset
+    description: ffmpeg x264 preset. Default "slower" (previews are small/short, so encode speed doesn't matter; better compression = better quality at the same CRF). Options ultrafast / superfast / veryfast / faster / fast / medium / slow / slower / veryslow.
+    type: STRING


### PR DESCRIPTION
## Summary

Live-library test showed flattened previews visibly softer than Stash's native previews. Two defaults to blame: \`-preset veryfast\` (no benefit on 10s / ~300KB clips) and \`-crf 23\` (x264's default for full-length, too aggressive on the second encode pass). New defaults: \`-preset slower -crf 18\` plus \`-profile:v high -pix_fmt yuv420p\` for broad player compatibility. Both knobs are configurable via plugin settings.

Bump to 0.2.0.

## Test plan

- [x] Unit tests pass (76)
- [x] ruff + pyright clean
- [ ] Re-run flatten on the live library with reprocess=true and compare hover-preview quality against Stash's native previews