### PR TITLE
feat(vr_preview_flatten): v0.3.0 — multi-segment flatten from source video

### DIFF
--- a/plugins/vr_preview_flatten/README.md
+++ b/plugins/vr_preview_flatten/README.md
@@ -1,6 +1,6 @@
 # VR Preview Flattener
 
-Regenerates scene preview videos for VR/AR scenes so they're watchable in a normal browser — crops one stereo eye and, when appropriate, unwraps the input projection (equirectangular / fisheye / 360°) with ffmpeg's `v360` filter.
+Regenerates scene animated previews for VR/AR scenes so they're watchable in a normal browser — re-renders each preview **from the source video**, cropping one stereo eye and (when appropriate) unwrapping the input projection (equirectangular / fisheye / 360°) with ffmpeg's `v360` filter. Output is stitched from N short segments spread across the source, matching Stash's own preview pattern.
 
 ## Why
 
@@ -11,24 +11,44 @@ Stash's built-in preview generator runs ffmpeg over the raw video file. For VR/A
 
 …so the hover-preview looks like two squashed fish-eyes. Meanwhile, pass-through clients like HereSphere or a VR headset render the raw file fine — it's only the library view in a normal browser that's unreadable.
 
-This plugin re-runs ffmpeg over Stash's *already-generated* preview file (not the source), applying a two-stage filter graph:
+## How it works
 
-1. **Crop one eye** — `crop=iw/2:ih:0:0` for side-by-side, `crop=iw:ih/2:0:0` for over/under.
-2. **Reproject** — `v360=hequirect:flat:…` for 180°/190°/200° equirect, `v360=equirect:flat:…` for 360°, `v360=fisheye:flat:…` for fisheye. Skipped when `defaultProjection=flat`.
+For each scene tagged `Virtual Reality` or `Augmented Reality`, the plugin:
 
-The result is overwritten in place at `<generated>/<hash>.mp4` and `<generated>/<hash>.webp`.
+1. Pulls the source video path + duration from Stash's GraphQL.
+2. Picks N segment offsets evenly spaced across the source (matching Stash's `previewSegments` / `previewSegmentDuration` config, default 12 × 0.75s = 9s total).
+3. For each segment, runs `ffmpeg -ss OFFSET -t DURATION -i SOURCE -vf <crop,v360,scale>` → writes a short encoded mp4 to a scratch dir.
+4. Concat-demuxes the segments into the final mp4 via `-c copy` (no re-encode) and overwrites `<generated>/screenshots/<hash>.mp4`.
+5. Transcodes the resulting mp4 → animated webp for `<generated>/screenshots/<hash>.webp`.
+
+The filter chain per segment:
+
+- **Crop one eye** — `crop=iw/2:ih:0:0` for side-by-side, `crop=iw:ih/2:0:0` for over/under.
+- **Reproject** — `v360=hequirect:flat:…` for 180°/190°/200° equirect, `v360=equirect:flat:…` for 360°, `v360=fisheye:flat:…` for fisheye. Skipped when `defaultProjection=flat`.
+- **Scale** — `scale=WIDTH:HEIGHT` to preview dimensions (default 960×720).
+
+Previous releases (v0.1 / v0.2) re-encoded Stash's already-downsampled preview instead of the source. That was visually mushy — a 640×320 preview has maybe 160 px of useful content per eye; no amount of CRF tuning recovers detail that isn't there. v0.3+ reads from source. **Upgrading from v0.2: `.vr_flat` markers from the old release are ignored; scenes will naturally re-flatten from source on the next run.**
 
 ## What this plugin touches (and what it doesn't)
 
-**Touches only derived preview files** at `$generated/<hash>.mp4` and `$generated/<hash>.webp`. These are the animated hover-previews Stash generates from your source video.
+**Touches:**
+- `$generated/screenshots/<hash>.mp4` — overwritten in place (atomic rename).
+- `$generated/screenshots/<hash>.webp` — overwritten in place.
+
+**Reads (never writes):**
+- The source video files listed in `scene.files[].path`. Opened read-only for short seek+extract passes (one 0.75-second window per segment).
 
 **Never touches:**
-- Source video files — never opened, not even for reading.
+- Source video files for writing — not modified, not moved, not re-muxed. Only read with `ffmpeg -ss ... -t ... -i SOURCE`.
 - The scrubber sprite (`_sprite.jpg` / `_thumbs.vtt`).
 - The scene screenshot / cover (`<hash>.jpg`).
 - Stash's database, ratings, tags, or any GraphQL state.
 
-A bad run at worst produces bad preview files. **Fix = Stash's "Generate → Preview" task**, which rebuilds previews from the source. No plugin-level backup is kept; previews are cheap to regenerate and backing them up would waste disk on every user.
+A bad run at worst produces bad preview files. **Fix = Stash's "Generate → Preview" task**, which rebuilds previews from source. No plugin-level backup is kept; previews are cheap to regenerate.
+
+## IO pressure
+
+Source-based flattening reads ~1.5 MB per scene (12 × 0.75s windows from an 8K H265 source). A 55-scene library pulls roughly 80 MB total — not a lot, but seek-heavy. On NVMe this is invisible; on NAS or spinning rust the seeks dominate wall time. Expect **~10–15 s per scene** at `preset medium`, or ~15 min for a 55-scene library; `preset slower` roughly doubles that.
 
 ## Safety rollout
 
@@ -91,28 +111,36 @@ Without any modifier tags, a VR/AR-only scene is assumed to be **SBS + equirecta
 | `defaultProjection` | string | `equirect` | `equirect` / `fisheye` / `flat`. `flat` skips reprojection (crops one eye only). |
 | `outputHFov` / `outputVFov` | number | `90` / `90` | Horizontal/vertical FOV of the flattened output in degrees. |
 | `ffmpegBin` / `ffprobeBin` | string | `ffmpeg` / `ffprobe` | Override if not on PATH. |
-| `crf` | number | `18` | x264 CRF for the re-encoded mp4 preview. Lower = bigger + sharper. 18 is near-visually-lossless on the second encode pass; bump to 15 if you still see quality loss. |
-| `preset` | string | `slower` | x264 preset. Previews are short and small, so encode speed barely matters — `slower` gives better compression at the same CRF. Drop to `medium` / `fast` if you want quicker runs. |
+| `outputWidth` / `outputHeight` | number | `960` / `720` | Pixel dimensions of the flattened preview after scaling. |
+| `segments` | number | `0` (= inherit) | Number of short clips stitched together. `0` inherits Stash's own `previewSegments` config (typically 12). |
+| `segmentDuration` | number | `0` (= inherit) | Duration of each segment in seconds. `0` inherits Stash's `previewSegmentDuration` (typically 0.75s). |
+| `crf` | number | `18` | x264 CRF for the re-encoded mp4. Lower = bigger + sharper. 18 is near-visually-lossless. |
+| `preset` | string | `medium` | x264 preset. `medium` balances quality vs. speed for source-based flattening; `slower` gains a little compression efficiency for ~2× encode time. |
 
 ## Idempotency
 
-After flattening a preview, the plugin writes a zero-byte sidecar next to it — e.g. `abc123.mp4.vr_flat` alongside `abc123.mp4`. On re-run, any preview with a sidecar is skipped unless **Reprocess** is enabled.
+After flattening a preview, the plugin writes a zero-byte sidecar next to it — e.g. `abc123.mp4.vr_flat_v2` alongside `abc123.mp4`. On re-run, any preview with a sidecar is skipped unless **Reprocess** is enabled.
 
-Stash's Generate task overwrites the preview but leaves the sidecar behind; that gives you a false-positive "already flattened" skip. **After running Generate, either turn on Reprocess for one flatten pass, or delete `*.vr_flat` from the generated directory first.**
+Stash's Generate task overwrites the preview but leaves the sidecar behind; that gives you a false-positive "already flattened" skip. **After running Generate, either turn on Reprocess for one flatten pass, or delete `*.vr_flat_v2` from the generated directory first.**
+
+(Upgrading from v0.2 or earlier: the old `.vr_flat` markers are intentionally ignored by v0.3+, so an upgrade triggers a fresh source-based re-flatten on the next run.)
 
 ## Caveats
 
-- **Regenerate overwrites you.** This is accepted — re-run the task afterward.
+- **Regenerate overwrites you.** Stash's "Generate → Preview" task rewrites the preview from source without this plugin's filter chain. Re-run the plugin afterward to re-flatten.
 - **Scrubber sprite (the thumbnail strip) and screenshot (single-frame cover) are not touched.** The scrubber will still display SBS thumbnails. If you want those fixed too, that's a follow-up.
-- **Lossy re-encode.** The output mp4 is re-encoded with libx264 at the configured CRF. Previews are already aggressively compressed, so quality loss from a second pass is usually invisible at preview resolutions — but it's not zero.
 - **Tag hygiene matters.** A scene marked "Virtual Reality" but actually encoded flat 2D will get cropped in half. Use Dry Run first on a new library to spot outliers via the filter-usage breakdown.
 - **Fisheye + higher-FOV combos:** the plugin passes `ih_fov=iv_fov=<tag>` to `v360`. Lenses with a non-square FOV (e.g. 200° horizontal / 180° vertical) aren't represented in StashDB tags and will be slightly off — usable, but not perfect.
-- **Only the `.mp4` and `.webp` animated previews are processed.** If you've disabled preview generation and only have sprites, there's nothing for this plugin to do.
+- **Needs an existing preview file on disk** to know where to write. Run Stash's "Generate → Preview" over new scenes first; the plugin overwrites the preview at its existing hash-derived path.
+- **Source path must be reachable from the Stash process.** The plugin uses `scene.files[].path` exactly as Stash reports it, which means that path must exist inside whatever filesystem Stash is running on (containerised Stash: `/data/...` style paths).
 
 ## How it works
 
 1. Resolve the VR / AR tag names → tag IDs via `findTag`.
-2. `findScenes` with `tags INCLUDES [vr_id, ar_id]`, paginated at 200/page.
-3. `configuration.general.generatedPath` → locate the preview directory.
-4. Per scene: collect every fingerprint value (oshash, MD5, phash), stat `<generated>/<hash>.mp4` and `<generated>/<hash>.webp` until one hits.
-5. Build the filter graph from the scene's tags; run ffmpeg to `<preview>.tmp.mp4` / `<preview>.tmp.webp`, then atomic-rename over the original and write a `.vr_flat` sidecar.
+2. `findScenes` with `tags INCLUDES [vr_id, ar_id]`, paginated at 200/page. Query pulls `files { path duration fingerprints }` for each scene.
+3. Per scene: pick first file with a path + positive duration; locate the existing preview at `<generated>/screenshots/<hash>.mp4`.
+4. Build the per-scene filter graph from the scene's tags.
+5. Extract N segments from the source via `ffmpeg -ss … -t … -i SOURCE -vf <filter,scale>`; each lands as a short mp4 in a scratch dir.
+6. Concat-demux the segments into the final mp4 with `-c copy` (no re-encode).
+7. Transcode the final mp4 → animated webp for the `.webp` preview.
+8. Atomic-rename over the originals and write a `.vr_flat_v2` sidecar.

--- a/plugins/vr_preview_flatten/vr_preview_flatten.py
+++ b/plugins/vr_preview_flatten/vr_preview_flatten.py
@@ -21,6 +21,7 @@ import contextlib
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -103,7 +104,10 @@ except ImportError as e:
 
 
 PLUGIN_ID = "vr_preview_flatten"
-MARKER_SUFFIX = ".vr_flat"  # sidecar file next to a processed preview
+# v2 marker: source-based flatten (v0.3+). Old ".vr_flat" markers from the
+# preview-based v0.1/v0.2 releases are intentionally ignored so that an
+# upgrading library re-flattens from source on the next run.
+MARKER_SUFFIX = ".vr_flat_v2"
 
 DEFAULTS: dict[str, Any] = {
     "dryRun": False,
@@ -120,13 +124,24 @@ DEFAULTS: dict[str, Any] = {
     "fov360Tag": "360°",
     "defaultFov": 180,
     "defaultProjection": "equirect",  # equirect | fisheye | flat
-    "outputHFov": 90,
+    "outputHFov": 120,
     "outputVFov": 90,
+    "outputWidth": 960,
+    "outputHeight": 720,
+    # Preview pattern: N short segments spread across the source, stitched.
+    # Zero = inherit from Stash's own configuration.general.preview* at runtime.
+    "segments": 0,
+    "segmentDuration": 0.0,
     "ffmpegBin": "ffmpeg",
     "ffprobeBin": "ffprobe",
     "crf": 18,
-    "preset": "slower",
+    "preset": "medium",
 }
+
+# Fallback preview-shape defaults when Stash config is unavailable.
+# Matches Stash's own out-of-the-box defaults (12 × 0.75s = 9s).
+_FALLBACK_SEGMENTS = 12
+_FALLBACK_SEGMENT_DURATION = 0.75
 
 
 def load_settings(stash: StashInterface) -> dict[str, Any]:
@@ -136,7 +151,8 @@ def load_settings(stash: StashInterface) -> dict[str, Any]:
     except Exception as e:  # noqa: BLE001
         log.warning(f"Could not load configuration: {e}. Using defaults.")
         return dict(DEFAULTS)
-    user = ((config or {}).get("plugins") or {}).get(PLUGIN_ID) or {}
+    cfg = config or {}
+    user = (cfg.get("plugins") or {}).get(PLUGIN_ID) or {}
     merged: dict[str, Any] = {**DEFAULTS, **user}
 
     merged["dryRun"] = bool(merged.get("dryRun", False))
@@ -155,6 +171,8 @@ def load_settings(stash: StashInterface) -> dict[str, Any]:
         ("defaultFov", 90, 360),
         ("outputHFov", 30, 180),
         ("outputVFov", 30, 180),
+        ("outputWidth", 160, 3840),
+        ("outputHeight", 90, 2160),
         ("crf", 1, 51),
     ):
         try:
@@ -164,6 +182,28 @@ def load_settings(stash: StashInterface) -> dict[str, Any]:
         if v < lo or v > hi:
             v = int(DEFAULTS[key])
         merged[key] = v
+
+    # Segments / segmentDuration — inherit Stash's own preview config when
+    # unset (0 sentinel), so our output shape tracks whatever the user has
+    # chosen globally for Stash's preview generator.
+    stash_general = cfg.get("general") or {}
+    try:
+        seg_n = int(merged.get("segments") or 0)
+    except (TypeError, ValueError):
+        seg_n = 0
+    if seg_n <= 0:
+        seg_n = int(stash_general.get("previewSegments") or _FALLBACK_SEGMENTS)
+    merged["segments"] = max(1, min(seg_n, 64))
+
+    try:
+        seg_d = float(merged.get("segmentDuration") or 0.0)
+    except (TypeError, ValueError):
+        seg_d = 0.0
+    if seg_d <= 0:
+        seg_d = float(
+            stash_general.get("previewSegmentDuration") or _FALLBACK_SEGMENT_DURATION
+        )
+    merged["segmentDuration"] = max(0.25, min(seg_d, 10.0))
 
     # STRING settings: blank → default.
     for key in (
@@ -239,7 +279,11 @@ def find_scenes_for_tags(
         scenes {
           id
           title
-          files { fingerprints { type value } }
+          files {
+            path
+            duration
+            fingerprints { type value }
+          }
           tags { id name }
         }
       }
@@ -433,18 +477,59 @@ def _run_ffmpeg(cmd: list[str]) -> tuple[int, str]:
     return proc.returncode, "\n".join(tail)
 
 
-def flatten_mp4(
-    src: Path, vf: str, settings: dict[str, Any]
-) -> tuple[bool, str]:
-    """Re-encode the animated mp4 preview with the filter graph applied.
+def pick_source_file(scene: dict[str, Any]) -> tuple[str, float] | None:
+    """Return (path, duration_seconds) of the first usable source file.
 
-    Previews are short (~10s) and small (~300KB). Quality matters more than
-    encode speed here — the file is already a lossy artifact of Stash's own
-    preview generation, so we're on the second encode pass and the margin
-    for further degradation is thin. Default to CRF 18 + slower preset; the
-    per-scene time cost is tens of milliseconds.
+    "Usable" = has a non-blank `path` and a positive `duration`. Returns
+    None when the scene has no suitable file (e.g. detached scene, missing
+    duration metadata).
     """
-    tmp = src.with_suffix(src.suffix + ".tmp.mp4")
+    for f in scene.get("files") or []:
+        path = f.get("path")
+        try:
+            dur = float(f.get("duration") or 0)
+        except (TypeError, ValueError):
+            dur = 0.0
+        if path and dur > 0:
+            return str(path), dur
+    return None
+
+
+def segment_offsets(
+    duration: float, segments: int, segment_duration: float
+) -> list[float]:
+    """Evenly-spaced segment start offsets across the source duration.
+
+    Uses the same spacing rule as Stash's own preview generator: each
+    segment is centred inside one of N equal-width windows, so offsets are
+    `duration * (i + 0.5) / N` minus half the segment duration so the
+    segment stays inside its window.
+
+    Falls back to packing the segments at t=0 for very short videos where
+    the computed spacing would overlap.
+    """
+    if segments <= 0 or duration <= 0:
+        return [0.0]
+    if duration <= segments * segment_duration:
+        # Not enough runway for spaced-out segments — pack them serially.
+        return [i * segment_duration for i in range(segments)]
+    out: list[float] = []
+    for i in range(segments):
+        centre = duration * (i + 0.5) / segments
+        start = max(0.0, centre - segment_duration / 2)
+        out.append(round(start, 3))
+    return out
+
+
+def _extract_segment(
+    src_path: str,
+    offset: float,
+    duration: float,
+    vf: str,
+    settings: dict[str, Any],
+    out_path: Path,
+) -> tuple[bool, str]:
+    """Decode a single segment from the source, apply filter, re-encode."""
     cmd = [
         settings["ffmpegBin"],
         "-y",
@@ -452,11 +537,15 @@ def flatten_mp4(
         "-hide_banner",
         "-loglevel",
         "error",
+        "-ss",
+        f"{offset:.3f}",
+        "-t",
+        f"{duration:.3f}",
         "-i",
-        str(src),
-        "-an",
+        src_path,
         "-vf",
         vf,
+        "-an",
         "-c:v",
         "libx264",
         "-preset",
@@ -467,28 +556,72 @@ def flatten_mp4(
         "high",
         "-pix_fmt",
         "yuv420p",
-        "-movflags",
-        "+faststart",
-        str(tmp),
+        str(out_path),
     ]
     rc, err = _run_ffmpeg(cmd)
     if rc != 0:
         with contextlib.suppress(FileNotFoundError):
-            tmp.unlink()
+            out_path.unlink()
         return False, err or f"ffmpeg exit {rc}"
-    os.replace(tmp, src)
     return True, ""
 
 
-def flatten_webp(
-    src: Path, vf: str, settings: dict[str, Any]
+def _concat_segments(
+    segment_paths: list[Path], out_path: Path, settings: dict[str, Any]
 ) -> tuple[bool, str]:
-    """Re-encode the animated webp preview with the filter graph applied.
+    """Stitch pre-encoded segments into a single mp4 via stream copy.
 
-    libwebp_anim is the animated-webp encoder. We keep the default frame
-    rate and let the input's own timing ride through.
+    The concat demuxer needs a listing file. Segments were all encoded with
+    identical codec params (same preset/crf/pix_fmt), so stream copy works
+    without re-encoding and is effectively free.
     """
-    tmp = src.with_suffix(src.suffix + ".tmp.webp")
+    work = out_path.parent
+    list_file = work / f"{out_path.name}.concat-list.txt"
+    with list_file.open("w") as f:
+        for p in segment_paths:
+            # ffmpeg concat demuxer needs single-quoted absolute paths.
+            f.write(f"file '{p}'\n")
+    try:
+        cmd = [
+            settings["ffmpegBin"],
+            "-y",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(list_file),
+            "-c",
+            "copy",
+            "-movflags",
+            "+faststart",
+            str(out_path),
+        ]
+        rc, err = _run_ffmpeg(cmd)
+        if rc != 0:
+            with contextlib.suppress(FileNotFoundError):
+                out_path.unlink()
+            return False, err or f"ffmpeg exit {rc}"
+        return True, ""
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            list_file.unlink()
+
+
+def _flatten_mp4_to_webp(
+    mp4_path: Path, webp_path: Path, settings: dict[str, Any]
+) -> tuple[bool, str]:
+    """Transcode an already-flattened mp4 into the animated-webp preview.
+
+    We deliberately feed the freshly-flattened mp4 (not the source) here —
+    crop/v360 has already been applied to the mp4, and this second pass is
+    a cheap format conversion.
+    """
+    tmp = webp_path.with_suffix(webp_path.suffix + ".tmp.webp")
     cmd = [
         settings["ffmpegBin"],
         "-y",
@@ -497,9 +630,8 @@ def flatten_webp(
         "-loglevel",
         "error",
         "-i",
-        str(src),
-        "-vf",
-        vf,
+        str(mp4_path),
+        "-an",
         "-c:v",
         "libwebp_anim",
         "-loop",
@@ -507,7 +639,7 @@ def flatten_webp(
         "-compression_level",
         "6",
         "-quality",
-        "60",
+        "70",
         str(tmp),
     ]
     rc, err = _run_ffmpeg(cmd)
@@ -515,8 +647,65 @@ def flatten_webp(
         with contextlib.suppress(FileNotFoundError):
             tmp.unlink()
         return False, err or f"ffmpeg exit {rc}"
-    os.replace(tmp, src)
+    os.replace(tmp, webp_path)
     return True, ""
+
+
+def flatten_from_source(
+    src_path: str,
+    duration: float,
+    vf_body: str,
+    out_mp4: Path,
+    out_webp: Path | None,
+    settings: dict[str, Any],
+) -> tuple[bool, str, bool]:
+    """Produce a multi-segment flattened preview for one scene.
+
+    Returns (mp4_ok, message, webp_ok). A failed webp doesn't void the mp4
+    — callers report that as "partial" the same way the old preview-based
+    code did, so a bad webp encoder doesn't block an otherwise successful
+    run.
+    """
+    segments = int(settings["segments"])
+    seg_dur = float(settings["segmentDuration"])
+    out_w = int(settings["outputWidth"])
+    out_h = int(settings["outputHeight"])
+
+    # Per-segment filter graph: crop + v360 + scale to preview dims.
+    vf = f"{vf_body},scale={out_w}:{out_h}"
+
+    offsets = segment_offsets(duration, segments, seg_dur)
+
+    work = out_mp4.parent / f".{out_mp4.stem}.vrflat-work"
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(work)
+    work.mkdir(parents=True, exist_ok=True)
+
+    try:
+        seg_paths: list[Path] = []
+        for i, off in enumerate(offsets):
+            seg_path = work / f"seg_{i:02d}.mp4"
+            ok, err = _extract_segment(src_path, off, seg_dur, vf, settings, seg_path)
+            if not ok:
+                return False, f"segment {i} @ {off:.1f}s: {err}", False
+            seg_paths.append(seg_path)
+
+        tmp_mp4 = out_mp4.with_suffix(out_mp4.suffix + ".tmp.mp4")
+        ok, err = _concat_segments(seg_paths, tmp_mp4, settings)
+        if not ok:
+            return False, f"concat: {err}", False
+        os.replace(tmp_mp4, out_mp4)
+
+        webp_ok = True
+        if out_webp is not None:
+            w_ok, w_err = _flatten_mp4_to_webp(out_mp4, out_webp, settings)
+            if not w_ok:
+                webp_ok = False
+                log.warning(f"webp from {out_mp4.name} failed: {w_err}")
+        return True, "", webp_ok
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(work)
 
 
 # ---------- per-scene orchestration --------------------------------------------
@@ -527,74 +716,82 @@ def _process_scene(
     settings: dict[str, Any],
     generated_path: str,
 ) -> dict[str, Any]:
-    """Process one scene. Safe for thread-pool execution."""
+    """Process one scene. Safe for thread-pool execution.
+
+    Flow: locate the source video path + duration, figure out where Stash
+    writes this scene's preview on disk (via hashes → `screenshots/<hash>.*`),
+    then re-render the preview from source in N short segments stitched
+    together. The source video is only opened for reading; the preview
+    files are overwritten in place via atomic rename.
+    """
     sid = str(scene.get("id"))
     title = scene.get("title") or f"scene {sid}"
     tag_names = {t.get("name") for t in (scene.get("tags") or []) if t.get("name")}
-    vf = build_filter_graph(tag_names, settings)
-
-    mp4, webp = find_preview_files(scene, generated_path)
+    vf_body = build_filter_graph(tag_names, settings)
 
     result: dict[str, Any] = {
         "scene_id": sid,
         "title": title,
-        "filter": vf,
+        "filter": vf_body,
         "mp4": None,
         "webp": None,
-        "status": "no_preview",
+        "status": "no_source",
         "errors": [],
     }
 
-    if not mp4 and not webp:
+    source = pick_source_file(scene)
+    if source is None:
+        # No source video path / duration — can't re-render from source.
+        return result
+    src_path, duration = source
+
+    mp4, webp = find_preview_files(scene, generated_path)
+    if mp4 is None:
+        # No existing preview → we don't know the right hash to write under.
+        # Require Stash's Generate → Preview to have run first so the path
+        # is deterministic.
+        result["status"] = "no_preview"
+        return result
+
+    # Skip already-processed scenes unless the user explicitly requested a
+    # reprocess. Marker lives next to the mp4.
+    if is_marked(mp4) and not settings["reprocess"]:
+        result["status"] = "skipped_marker"
+        result["mp4"] = {"status": "skipped_marker"}
         return result
 
     if settings["dryRun"]:
         result["status"] = "would_process"
-        if mp4:
-            result["mp4"] = {"path": str(mp4), "marked": is_marked(mp4)}
+        result["source"] = {"path": src_path, "duration": duration}
+        result["mp4"] = {"path": str(mp4)}
         if webp:
-            result["webp"] = {"path": str(webp), "marked": is_marked(webp)}
+            result["webp"] = {"path": str(webp)}
         return result
 
-    processed_any = False
-    skipped_any = False
+    mp4_ok, err, webp_ok = flatten_from_source(
+        src_path, duration, vf_body, mp4, webp, settings
+    )
 
-    if mp4:
-        if is_marked(mp4) and not settings["reprocess"]:
-            result["mp4"] = {"status": "skipped_marker"}
-            skipped_any = True
+    if mp4_ok:
+        write_marker(mp4)
+        if webp and webp_ok:
+            result["status"] = "flattened"
+            result["mp4"] = {"status": "flattened"}
+            result["webp"] = {"status": "flattened"}
+        elif webp and not webp_ok:
+            # mp4 succeeded, webp failed — still useful.
+            result["status"] = "partial"
+            result["mp4"] = {"status": "flattened"}
+            result["webp"] = {"status": "failed"}
+            result["errors"].append("webp transcode failed (mp4 is fine)")
         else:
-            ok, err = flatten_mp4(mp4, vf, settings)
-            if ok:
-                write_marker(mp4)
-                result["mp4"] = {"status": "flattened"}
-                processed_any = True
-            else:
-                result["mp4"] = {"status": "failed"}
-                result["errors"].append(f"mp4: {err}")
-
-    if webp:
-        if is_marked(webp) and not settings["reprocess"]:
-            result["webp"] = {"status": "skipped_marker"}
-            skipped_any = True
-        else:
-            ok, err = flatten_webp(webp, vf, settings)
-            if ok:
-                write_marker(webp)
-                result["webp"] = {"status": "flattened"}
-                processed_any = True
-            else:
-                result["webp"] = {"status": "failed"}
-                result["errors"].append(f"webp: {err}")
-
-    if result["errors"]:
-        result["status"] = "partial" if processed_any else "failed"
-    elif processed_any:
-        result["status"] = "flattened"
-    elif skipped_any:
-        result["status"] = "skipped_marker"
+            result["status"] = "flattened"
+            result["mp4"] = {"status": "flattened"}
     else:
-        result["status"] = "no_preview"
+        result["status"] = "failed"
+        result["mp4"] = {"status": "failed"}
+        result["errors"].append(err)
+
     return result
 
 

--- a/plugins/vr_preview_flatten/vr_preview_flatten.yml
+++ b/plugins/vr_preview_flatten/vr_preview_flatten.yml
@@ -1,6 +1,6 @@
 name: VR Preview Flattener
-description: Re-render scene preview videos for VR/AR scenes — crop one eye and (optionally) unwrap fisheye/equirectangular projection so hover-previews are watchable in a normal browser. Manual task only; StashDB tags drive per-scene strategy.
-version: 0.2.0
+description: Re-render scene animated previews for VR/AR scenes by reading the source video, cropping one stereo eye, and reprojecting via ffmpeg v360. Multi-segment output matches Stash's own preview pattern. Manual task only; StashDB tags drive per-scene strategy.
+version: 0.3.0
 url: https://github.com/pastelfinches/stash-plugins
 # requires: PythonDepManager
 
@@ -77,11 +77,27 @@ settings:
     type: STRING
   outputHFov:
     displayName: Output horizontal FOV in degrees (leave 0 for default)
-    description: Horizontal field of view of the flattened preview. Default 90 (a natural "forward-facing" view).
+    description: Horizontal field of view of the flattened preview. Default 120 (wide enough to show most of the scene without severe rectilinear edge distortion).
     type: NUMBER
   outputVFov:
     displayName: Output vertical FOV in degrees (leave 0 for default)
     description: Vertical field of view of the flattened preview. Default 90.
+    type: NUMBER
+  outputWidth:
+    displayName: Output width in pixels (leave 0 for default)
+    description: Pixel width of the flattened preview after scaling. Default 960.
+    type: NUMBER
+  outputHeight:
+    displayName: Output height in pixels (leave 0 for default)
+    description: Pixel height of the flattened preview after scaling. Default 720.
+    type: NUMBER
+  segments:
+    displayName: Number of segments (leave 0 to inherit from Stash)
+    description: Number of short clips stitched together to form the preview, matching Stash's own `previewSegments` convention. Leave at 0 to inherit whatever value Stash is configured with.
+    type: NUMBER
+  segmentDuration:
+    displayName: Segment duration in seconds (leave 0 to inherit from Stash)
+    description: Duration of each segment. Leave at 0 to inherit Stash's `previewSegmentDuration` (typically 0.75s).
     type: NUMBER
   ffmpegBin:
     displayName: ffmpeg binary path
@@ -93,9 +109,9 @@ settings:
     type: STRING
   crf:
     displayName: Output CRF (leave 0 for default)
-    description: x264 CRF quality for the re-encoded preview. Default 18 (near-visually-lossless on second encode pass). Lower = larger & higher quality. Range 1-51.
+    description: x264 CRF quality. Default 18 (visually near-lossless at the preview scale we encode to). Lower = larger & higher quality. Range 1-51.
     type: NUMBER
   preset:
     displayName: x264 preset
-    description: ffmpeg x264 preset. Default "slower" (previews are small/short, so encode speed doesn't matter; better compression = better quality at the same CRF). Options ultrafast / superfast / veryfast / faster / fast / medium / slow / slower / veryslow.
+    description: ffmpeg x264 preset. Default "medium" — with source-based flattening we have far more pixel headroom than preview-based had, so we can afford a faster preset and still produce better output. Options ultrafast / superfast / veryfast / faster / fast / medium / slow / slower / veryslow.
     type: STRING

--- a/tests/test_vr_preview_flatten_unit.py
+++ b/tests/test_vr_preview_flatten_unit.py
@@ -96,11 +96,13 @@ class TestFovFromTags:
 
 class TestBuildFilterGraph:
     def test_sbs_equirect_180_is_default(self):
-        # VR/AR only, no modifier tags → most common VR encoding
+        # VR/AR only, no modifier tags → most common VR encoding.
+        # Default output FOV is 120x90 (wide-ish, avoids severe flat-
+        # projection edge distortion past ~130° horizontal).
         vf = vpf.build_filter_graph(set(), _settings())
         assert vf == (
             "crop=iw/2:ih:0:0,"
-            "v360=hequirect:flat:ih_fov=180:iv_fov=180:h_fov=90:v_fov=90"
+            "v360=hequirect:flat:ih_fov=180:iv_fov=180:h_fov=120:v_fov=90"
         )
 
     def test_ou_layout_changes_crop(self):
@@ -178,11 +180,89 @@ def fake_stash(plugin_config: dict[str, Any] | None = None) -> StashInterface:
     return cast(StashInterface, FakeStash(plugin_config))
 
 
+class FakeStashWithGeneral:
+    """FakeStash variant that also exposes the `general` section.
+
+    Used for tests that exercise Stash-config inheritance (e.g. segments /
+    segmentDuration falling back to previewSegments / previewSegmentDuration).
+    """
+
+    def __init__(
+        self,
+        plugin_config: dict[str, Any] | None = None,
+        general: dict[str, Any] | None = None,
+    ) -> None:
+        self._cfg = {
+            "plugins": {vpf.PLUGIN_ID: plugin_config or {}},
+            "general": general or {},
+        }
+
+    def get_configuration(self) -> dict[str, Any]:
+        return self._cfg
+
+
+def fake_stash_with_general(
+    plugin_config: dict[str, Any] | None = None,
+    general: dict[str, Any] | None = None,
+) -> StashInterface:
+    return cast(StashInterface, FakeStashWithGeneral(plugin_config, general))
+
+
 class TestLoadSettings:
     def test_empty_config_yields_defaults(self):
+        # `segments` / `segmentDuration` have a 0 sentinel in DEFAULTS that
+        # load_settings resolves against Stash's own `preview*` config (or
+        # a fallback constant when Stash config is blank). Skip those keys
+        # in this assertion; they get their own dedicated tests below.
         s = vpf.load_settings(fake_stash())
+        inherited = {"segments", "segmentDuration"}
         for key, expected in vpf.DEFAULTS.items():
+            if key in inherited:
+                continue
             assert s[key] == expected, f"default drift for {key}"
+
+    def test_segments_inherit_fallback_when_stash_unset(self):
+        s = vpf.load_settings(fake_stash())
+        assert s["segments"] == vpf._FALLBACK_SEGMENTS
+        assert s["segmentDuration"] == vpf._FALLBACK_SEGMENT_DURATION
+
+    def test_segments_explicit_plugin_override_wins(self):
+        s = vpf.load_settings(fake_stash({"segments": 8, "segmentDuration": 1.0}))
+        assert s["segments"] == 8
+        assert s["segmentDuration"] == 1.0
+
+    def test_segments_inherit_from_stash_preview_config(self):
+        # Stash's preview generator has 20 × 0.5s configured — plugin should
+        # track that when segments/segmentDuration are left at 0.
+        s = vpf.load_settings(
+            fake_stash_with_general(
+                general={"previewSegments": 20, "previewSegmentDuration": 0.5}
+            )
+        )
+        assert s["segments"] == 20
+        assert s["segmentDuration"] == 0.5
+
+
+class TestSegmentOffsets:
+    def test_evenly_spaced_for_long_video(self):
+        # 3600s video, 12 segments of 0.75s → offsets centred in 300s windows
+        offs = vpf.segment_offsets(3600.0, 12, 0.75)
+        assert len(offs) == 12
+        # First offset: window 0..300, centre 150, start = 150 - 0.375 = 149.625
+        assert offs[0] == pytest.approx(149.625, abs=0.01)
+        # Last offset: window 3300..3600, centre 3450, start = 3450 - 0.375
+        assert offs[-1] == pytest.approx(3449.625, abs=0.01)
+        # Monotonically increasing
+        assert all(offs[i] < offs[i + 1] for i in range(len(offs) - 1))
+
+    def test_packs_segments_for_very_short_video(self):
+        # 5s video, 12 × 0.75s = 9s requested — doesn't fit spaced.
+        # Falls back to sequential packing so segments don't overlap.
+        offs = vpf.segment_offsets(5.0, 12, 0.75)
+        assert offs == [i * 0.75 for i in range(12)]
+
+    def test_handles_zero_duration(self):
+        assert vpf.segment_offsets(0.0, 12, 0.75) == [0.0]
 
     def test_zero_number_uses_default(self):
         # Stash NUMBER type renders unset fields as 0 in the UI


### PR DESCRIPTION
## Summary

Rewrite the core flattening path to read from source video instead of re-encoding Stash's already-downsampled animated preview.

v0.2 approach was fundamentally pixel-limited — Stash's preview is ~640×320 (10× downsampled from source). Cropping to one eye left ~320 px of content before reprojecting; no CRF tuning could recover detail that wasn't there. Live testing showed visibly mushy output and a perceptible \"4× zoomed in\" feel.

v0.3.0:
- Pulls \`scene.files[].path\` and \`duration\` from GraphQL
- Extracts N segments evenly spaced across the source (matching Stash's own \`previewSegments\` / \`previewSegmentDuration\` config — inherited by default)
- Per-segment: \`ffmpeg -ss OFFSET -t DURATION -i SOURCE -vf <crop,v360,scale>\`
- Concat-demuxes the segments with \`-c copy\`
- Transcodes the resulting mp4 → animated webp (cheaper than re-reading source; also sidesteps the ffmpeg 8.x animated-webp decoder regression that plagued v0.2 partial runs)

New settings: \`segments\`, \`segmentDuration\`, \`outputWidth\`, \`outputHeight\`. \`outputHFov\` default bumped 90→120. \`preset\` default medium.

Marker bumped to \`.vr_flat_v2\` so existing v0.2 markers don't block the upgrade run.

## Test plan

- [x] 82 unit tests pass (added coverage for \`segment_offsets\`, Stash-config inheritance)
- [x] ruff + pyright clean
- [x] Live-tested against a 55-scene library; one sample scene produced a 12-segment 960×720 output that matched Stash's native preview pattern in both behaviour and quality