### PR TITLE
fix(vr_preview_flatten): v0.3.1 — keep source-based flatten under 4 GB RSS

### DIFF
--- a/plugins/vr_preview_flatten/README.md
+++ b/plugins/vr_preview_flatten/README.md
@@ -46,9 +46,13 @@ Previous releases (v0.1 / v0.2) re-encoded Stash's already-downsampled preview i
 
 A bad run at worst produces bad preview files. **Fix = Stash's "Generate → Preview" task**, which rebuilds previews from source. No plugin-level backup is kept; previews are cheap to regenerate.
 
-## IO pressure
+## IO & memory pressure
 
-Source-based flattening reads ~1.5 MB per scene (12 × 0.75s windows from an 8K H265 source). A 55-scene library pulls roughly 80 MB total — not a lot, but seek-heavy. On NVMe this is invisible; on NAS or spinning rust the seeks dominate wall time. Expect **~10–15 s per scene** at `preset medium`, or ~15 min for a 55-scene library; `preset slower` roughly doubles that.
+**IO:** Source-based flattening reads ~1.5 MB per scene (12 × 0.75s windows from an 8K H.265 source). A 55-scene library pulls roughly 80 MB total — not a lot, but seek-heavy. On NVMe this is invisible; on NAS or spinning rust the seeks dominate wall time.
+
+**Memory:** An 8K HEVC decoder + libx264 encoder with `-threads 4` peaks around **2.5–3 GB RSS** per running ffmpeg. Default `workers=1` stays under the 4 GB memory limit a container-deployed Stash typically has. Raising workers multiplies this roughly linearly — on a 4 GB Stash container, `workers: 2` will OOM-kill Stash mid-run. If your Stash is on a beefy bare-metal host with RAM to spare, 2–3 workers is fine; otherwise leave `workers: 1`.
+
+**Wall time:** ~70–90 s per scene at `preset medium` with `workers: 1` on an 8K source. A 55-scene library takes ~75 min serially; running `workers: 2` roughly halves that on a host with sufficient RAM.
 
 ## Safety rollout
 
@@ -116,6 +120,8 @@ Without any modifier tags, a VR/AR-only scene is assumed to be **SBS + equirecta
 | `segmentDuration` | number | `0` (= inherit) | Duration of each segment in seconds. `0` inherits Stash's `previewSegmentDuration` (typically 0.75s). |
 | `crf` | number | `18` | x264 CRF for the re-encoded mp4. Lower = bigger + sharper. 18 is near-visually-lossless. |
 | `preset` | string | `medium` | x264 preset. `medium` balances quality vs. speed for source-based flattening; `slower` gains a little compression efficiency for ~2× encode time. |
+| `workers` | number | `1` | Scenes processed in parallel. Each worker decodes a 4K/8K source and can hold >1 GB of decoder state. **Default 1** to avoid OOM on default-sized Stash containers. Raise to 2–3 on hosts with 16+ GB free RAM. |
+| `ffmpegThreads` | number | `4` | `-threads N` cap on ffmpeg's internal parallelism. Default 4 keeps 8K HEVC decode ≤~1 GB RSS. Set 0 to let ffmpeg auto-pick (can spike memory on high-core hosts). |
 
 ## Idempotency
 

--- a/plugins/vr_preview_flatten/vr_preview_flatten.py
+++ b/plugins/vr_preview_flatten/vr_preview_flatten.py
@@ -113,7 +113,12 @@ DEFAULTS: dict[str, Any] = {
     "dryRun": False,
     "reprocess": False,
     "limit": 0,
-    "workers": 2,
+    # Source-based flattening runs ffmpeg against the raw 4K/8K source.
+    # A single decoder can hold >1 GB of frame data; two concurrent workers
+    # will OOM a default-sized Stash container (~4 GB memory limit). Keep
+    # the default at 1 and let users raise it if they have headroom.
+    "workers": 1,
+    "ffmpegThreads": 4,
     "virtualRealityTag": "Virtual Reality",
     "augmentedRealityTag": "Augmented Reality",
     "fisheyeTag": "Fisheye",
@@ -168,6 +173,7 @@ def load_settings(stash: StashInterface) -> dict[str, Any]:
     # NUMBER settings: treat 0/missing/out-of-range as "use default".
     for key, lo, hi in (
         ("workers", 1, 32),
+        ("ffmpegThreads", 0, 32),
         ("defaultFov", 90, 360),
         ("outputHFov", 30, 180),
         ("outputVFov", 30, 180),
@@ -529,7 +535,16 @@ def _extract_segment(
     settings: dict[str, Any],
     out_path: Path,
 ) -> tuple[bool, str]:
-    """Decode a single segment from the source, apply filter, re-encode."""
+    """Decode a single segment from the source, apply filter, re-encode.
+
+    `-threads N` caps ffmpeg's internal decoder+filter+encoder parallelism.
+    Default 4 — large enough to hide H.264 decoder latency on a modern
+    8-core box, small enough to keep a single 8K HEVC source decode below
+    ~1 GB RSS. Plugin-level workers>1 multiplies this, so a user who
+    wants high throughput should raise workers first, threads second.
+    """
+    threads = int(settings.get("ffmpegThreads") or 0)
+    thread_args = ["-threads", str(threads)] if threads > 0 else []
     cmd = [
         settings["ffmpegBin"],
         "-y",
@@ -537,6 +552,7 @@ def _extract_segment(
         "-hide_banner",
         "-loglevel",
         "error",
+        *thread_args,
         "-ss",
         f"{offset:.3f}",
         "-t",
@@ -556,6 +572,7 @@ def _extract_segment(
         "high",
         "-pix_fmt",
         "yuv420p",
+        *thread_args,
         str(out_path),
     ]
     rc, err = _run_ffmpeg(cmd)

--- a/plugins/vr_preview_flatten/vr_preview_flatten.yml
+++ b/plugins/vr_preview_flatten/vr_preview_flatten.yml
@@ -1,6 +1,6 @@
 name: VR Preview Flattener
 description: Re-render scene animated previews for VR/AR scenes by reading the source video, cropping one stereo eye, and reprojecting via ffmpeg v360. Multi-segment output matches Stash's own preview pattern. Manual task only; StashDB tags drive per-scene strategy.
-version: 0.3.0
+version: 0.3.1
 url: https://github.com/pastelfinches/stash-plugins
 # requires: PythonDepManager
 
@@ -33,7 +33,11 @@ settings:
     type: NUMBER
   workers:
     displayName: Worker threads (leave 0 for default)
-    description: Number of scenes processed in parallel. ffmpeg is CPU-heavy — keep this low (default 2).
+    description: Number of scenes processed in parallel. Default 1 — source-based flatten decodes 4K/8K video and each concurrent worker holds ~1 GB of decoder state. Raising past 1 on a container with less than ~8 GB RAM risks OOM. On a beefy host with 16+ GB of free memory, 2–3 is safe.
+    type: NUMBER
+  ffmpegThreads:
+    displayName: ffmpeg thread cap (leave 0 for default)
+    description: Caps ffmpeg's internal decoder+encoder parallelism via `-threads N`. Default 4 — a reasonable balance for 8K HEVC decode plus libx264 encode. Set 0 to let ffmpeg auto-pick (can spike memory on high-core hosts).
     type: NUMBER
   virtualRealityTag:
     displayName: Virtual Reality tag name

--- a/tests/test_vr_preview_flatten_unit.py
+++ b/tests/test_vr_preview_flatten_unit.py
@@ -231,6 +231,23 @@ class TestLoadSettings:
         assert s["segments"] == 8
         assert s["segmentDuration"] == 1.0
 
+    def test_ffmpeg_threads_default_and_explicit_zero(self):
+        # Default is 4 (capped to prevent decoder memory spikes).
+        s = vpf.load_settings(fake_stash())
+        assert s["ffmpegThreads"] == 4
+        # Explicit 0 means "let ffmpeg auto-pick" — honoured, not replaced.
+        s0 = vpf.load_settings(fake_stash({"ffmpegThreads": 0}))
+        assert s0["ffmpegThreads"] == 0
+        # Out-of-range clamps to default.
+        s_bad = vpf.load_settings(fake_stash({"ffmpegThreads": 999}))
+        assert s_bad["ffmpegThreads"] == 4
+
+    def test_workers_default_is_one(self):
+        # Source-based flatten needs a single-worker default so a fresh
+        # install doesn't OOM a default-sized Stash container.
+        s = vpf.load_settings(fake_stash())
+        assert s["workers"] == 1
+
     def test_segments_inherit_from_stash_preview_config(self):
         # Stash's preview generator has 20 × 0.5s configured — plugin should
         # track that when segments/segmentDuration are left at 0.


### PR DESCRIPTION
## Summary

v0.3.0 crashed a 4 GB Stash container on first run. Each 8K HEVC decode + libx264 encode holds ~2.5 GB RSS; `workers=2` with uncapped ffmpeg threads OOM-killed the pod.

- \`workers\` default 2 → 1
- New \`ffmpegThreads\` setting (default 4) caps ffmpeg's internal parallelism via \`-threads N\`
- README documents the memory math and workers/threads interaction

Live-verified on the user's container: steady-state ~800 MiB (between segments) to ~3 GiB (peak decode), under the 4 GB limit.

## Test plan

- [x] 84 unit tests pass (added coverage for thread-cap settings + workers=1 default)
- [x] ruff clean
- [x] Live run on the user's library with workers=1, -threads 4 stayed under the OOM line